### PR TITLE
FIx config generation

### DIFF
--- a/configgenerator.py
+++ b/configgenerator.py
@@ -22,7 +22,7 @@ DOCKERCOMPOSE = {
 
 
 def input_with_default(prompt, default):
-    result = input(f"{prompt}({default=})")
+    result = input(f"{prompt}({default})")
     if not result:
         return default
     return result

--- a/klinklang_public/core/config_generation/input_with_default.py
+++ b/klinklang_public/core/config_generation/input_with_default.py
@@ -1,5 +1,5 @@
 def input_with_default(prompt, default):
-    result = input(f"{prompt}({default=})")
+    result = input(f"{prompt}({default})")
     if not result:
         return default
     return result


### PR DESCRIPTION
Removing the `=` from the call to print `default` in order to get the config generation script to run.